### PR TITLE
modifying load_timeseries

### DIFF
--- a/R/load_timeseries.R
+++ b/R/load_timeseries.R
@@ -1,32 +1,40 @@
-#'@title load timeseries into local R environment 
-#'@description load timeseries into local R environment. Will download timeseries into 
-#'temp file, import it into R as a data.frame, and delete the temporary file. 
-#'@param site a valid powstreams site (see \code{\link{list_sites}})
-#'@param variable a valid variable name for timeseries data, or a vector of variable names
-#'@param session a valid sciencebase session (see \code{\link[sbtools]{authenticate_sb}}). 
-#'Set \code{session = NULL} (default) for sites on sciencebase that are public.
-#'@return timeseries data.frame. Will be matched in time if multiple variables are used for \code{variable}
-#'@examples
-#'\dontrun{
-#'dissolved_oxygen <- load_timeseries(site = 'nwis_01018035', variable = 'doobs')
-#'metab_input <- load_timeseries(site = 'nwis_01408500', variable = c('doobs','wtr'))
-#'}
-#'@seealso \code{\link{list_timeseries}}, \code{\link{list_sites}}
-#'@importFrom dplyr inner_join
-#'@importFrom mda.streams read_ts
-#'@export
-load_timeseries = function(site, variable, session = NULL){
+#' @title load timeseries into local R environment
+#' @description load timeseries into local R environment. Will download 
+#'   timeseries into temp file, import it into R as a data.frame, and delete the
+#'   temporary file.
+#' @param site a valid powstreams site (see \code{\link{list_sites}})
+#' @param variables a valid variable name for timeseries data, or a vector of 
+#'   variable names
+#' @param join.fun The \pkg{dplyr} function to use when successively adding the 
+#'   second, third, ... variables in \code{variables}. Good options include 
+#'   \code{\link{inner_join}}, \code{\link{full_join}}, and 
+#'   \code{\link{left_join}}.
+#' @param session a valid sciencebase session (see 
+#'   \code{\link[sbtools]{authenticate_sb}}). Set \code{session = NULL}
+#'   (default) for sites on sciencebase that are public.
+#' @return timeseries data.frame. Will be matched in time if multiple variables 
+#'   are used for \code{variable}
+#' @examples
+#' \dontrun{
+#' dissolved_oxygen <- load_timeseries(site = 'nwis_01018035', variable = 'doobs')
+#' metab_input <- load_timeseries(site = 'nwis_01408500', variable = c('doobs','wtr'))
+#' }
+#' @seealso \code{\link{list_timeseries}}, \code{\link{list_sites}}
+#' @importFrom dplyr inner_join
+#' @importFrom mda.streams read_ts
+#' @export
+load_timeseries = function(site, variables, join.fun=inner_join, session = NULL){
   
   # we read gzip compression directly w/ httr::GET? see ls(httr:::parsers)
-  file_handle <- download_timeseries(site, variable[1], destination = NULL, session = session, overwrite = TRUE)
+  file_handle <- download_timeseries(site, variables[1], destination = NULL, session = session, overwrite = TRUE)
   
   timeseries <- read_ts(file_handle)
   
-  if (length(variable) > 1){
-    for (i in 2:length(variable)){
-      file_handle <- download_timeseries(site, variable[i], destination = NULL, session = session, overwrite = TRUE)
+  if (length(variables) > 1){
+    for (i in 2:length(variables)){
+      file_handle <- download_timeseries(site, variables[i], destination = NULL, session = session, overwrite = TRUE)
       data <- read_ts(file_handle)
-      timeseries <- inner_join(x = timeseries, y = data, by = 'DateTime')
+      timeseries <- join.fun(x = timeseries, y = data, by = 'DateTime')
     }
   }
   

--- a/man/load_timeseries.Rd
+++ b/man/load_timeseries.Rd
@@ -4,22 +4,31 @@
 \alias{load_timeseries}
 \title{load timeseries into local R environment}
 \usage{
-load_timeseries(site, variable, session = NULL)
+load_timeseries(site, variables, join.fun = inner_join, session = NULL)
 }
 \arguments{
 \item{site}{a valid powstreams site (see \code{\link{list_sites}})}
 
-\item{variable}{a valid variable name for timeseries data, or a vector of variable names}
+\item{variables}{a valid variable name for timeseries data, or a vector of
+variable names}
 
-\item{session}{a valid sciencebase session (see \code{\link[sbtools]{authenticate_sb}}).
-Set \code{session = NULL} (default) for sites on sciencebase that are public.}
+\item{join.fun}{The \pkg{dplyr} function to use when successively adding the
+second, third, ... variables in \code{variables}. Good options include
+\code{\link{inner_join}}, \code{\link{full_join}}, and
+\code{\link{left_join}}.}
+
+\item{session}{a valid sciencebase session (see
+\code{\link[sbtools]{authenticate_sb}}). Set \code{session = NULL}
+(default) for sites on sciencebase that are public.}
 }
 \value{
-timeseries data.frame. Will be matched in time if multiple variables are used for \code{variable}
+timeseries data.frame. Will be matched in time if multiple variables
+  are used for \code{variable}
 }
 \description{
-load timeseries into local R environment. Will download timeseries into
-temp file, import it into R as a data.frame, and delete the temporary file.
+load timeseries into local R environment. Will download
+  timeseries into temp file, import it into R as a data.frame, and delete the
+  temporary file.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
@jread-usgs @lawinslow - do these API changes to load_timeseries() look OK to you?

* changed arg "variable" to "variables" to make it clearer that you can pass several at once.

* added arg join.fun, default of inner_join, so the user can decide whether to use inner/full/left/etc. dplyr join instead of always inner. inner_join can drop a lot of rows that we might prefer to see as NAs.